### PR TITLE
Obfuscation fixes

### DIFF
--- a/nodedb.py
+++ b/nodedb.py
@@ -229,6 +229,7 @@ class NodeDB:
     for link in self._links:
       ids = link.source.interface
       idt = link.target.interface
+
       try:
         node_source = self.maybe_node_by_fuzzy_mac(ids)
         node_target = self.maybe_node_by_id(idt)
@@ -242,7 +243,7 @@ class NodeDB:
           # This is for corner cases, when a client
           # is linked to another client.
           clientIds[ids] = str(globalIdCounter)
-          id1 = str(globalIdCounter)
+          ids = str(globalIdCounter)
           globalIdCounter += 1
 
           clientIds[idt] = str(globalIdCounter)
@@ -267,7 +268,7 @@ class NodeDB:
 
         link.id = ids + "-" + idt
 
-      except:
+      except KeyError:
         pass
 
 # extends node id by incremented node counter


### PR DESCRIPTION
Disabling client mac obfuscation lead to broken links between nodes and wrong wifi connection counts.
