### PR TITLE
nodedb.py: stop similar mac address check when parts are not equal

### DIFF
--- a/nodedb.py
+++ b/nodedb.py
@@ -324,6 +324,9 @@ def is_derived_mac(a, b):
   except ValueError:
     return False
 
+  if mac_a[4] != mac_b[4] or mac_a[2] != mac_b[2] or mac_a[1] != mac_b[1]:
+    return False
+
   x = list(mac_a)
   x[5] += 1
   x[5] %= 255


### PR DESCRIPTION
According to profiling results the "is_derived_mac" method is the most called, most time consuming function in ffmap-backend, except for the rrdtool image generation. The following patch contains a simple optimization, skipping the main part of the function if none manipulated parts of the mac address are not equal.
