### PR TITLE
Patch 2 - mkmap.sh executable from everywhere

### DIFF
--- a/mkmap.sh
+++ b/mkmap.sh
@@ -2,14 +2,24 @@
 
 set -e
 
+here=$(dirname $0)
+
 DEST=$1
-
-
 [ "$DEST" ] || exit 1
+
+if [ -x /usr/bin/realpath ]; then
+        #echo -n "I: changed path '$DEST' to "
+        DEST=$(realpath $DEST)
+        #echo "'$DEST'"
+fi
 
 cd "$(dirname "$0")"/
 
 ./ffhlwiki.py http://freifunk.metameute.de/wiki/Knoten > aliases_hl.json
 ./ffhlwiki.py http://freifunk.metameute.de/wiki/Moelln:Knoten > aliases_moelln.json
 
-./bat2nodes.py -A -a aliases.json -a aliases_hl.json -a aliases_moelln.json -d $DEST
+EXTRABIN=$HOME
+
+PATH=$EXTRABIN:$PATH ./bat2nodes.py -A -d $DEST
+
+#./bat2nodes.py -A -a aliases.json -a aliases_hl.json -a aliases_moelln.json -d $DEST

--- a/mkmap.sh
+++ b/mkmap.sh
@@ -15,9 +15,6 @@ fi
 
 cd "$(dirname "$0")"/
 
-./ffhlwiki.py http://freifunk.metameute.de/wiki/Knoten > aliases_hl.json
-./ffhlwiki.py http://freifunk.metameute.de/wiki/Moelln:Knoten > aliases_moelln.json
-
 EXTRABIN=$HOME
 
 PATH=$EXTRABIN:$PATH ./bat2nodes.py -A -d $DEST


### PR DESCRIPTION
For simplicitly and consistency, also the dependency on the manually curated nodes table of the wiki was removed.