### PR TITLE
Nodes ohne namen nicht in der state.json speichern

### DIFF
--- a/nodedb.py
+++ b/nodedb.py
@@ -28,12 +28,13 @@ class NodeDB:
     obj = []
 
     for node in self._nodes:
-      obj.append({ 'id': node.id
-                 , 'name': node.name
-                 , 'lastseen': node.lastseen
-                 , 'firstseen': node.firstseen
-                 , 'geo': node.gps
-                 })
+      if (node.name != ''):
+        obj.append({ 'id': node.id
+                   , 'name': node.name
+                   , 'lastseen': node.lastseen
+                   , 'firstseen': node.firstseen
+                   , 'geo': node.gps
+                   })
 
     with open(filename, "w") as f:
       json.dump(obj, f)


### PR DESCRIPTION
Machmal liefert batadv-vis die MAc Adressen von Nodes zu denen es keine Daten im Alfred gibt. 
Diese Nodes erscheinen dann in der Liste der Nodes nur mit einer MAC Adresse. 
Wenn diese Nodes beim speichern der state.json ausgefiltert werden werden sowohl die Liste der Nodes als auch die state.json von diesem unnötigem Ballast verschont. 
