### PR TITLE
Update to argparser, add --with-hidden-ownership option

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -136,8 +136,9 @@ if __name__ == '__main__':
                         metavar='FILE')
     parser.add_argument('-m', '--mesh',
                         default=['bat0'], nargs='+',
-                        help='Use given batman-adv mesh interface(s) (defaults to bat0); '
-                             'specify alfred unix socket like bat0:/run/alfred0.sock.')
+                        help='Use given batman-adv mesh interface(s) (defaults'
+                             'to bat0); specify alfred unix socket like '
+                             'bat0:/run/alfred0.sock.')
     parser.add_argument('-d', '--dest-dir', action='store',
                         help='Write output to destination directory',
                         required=True)

--- a/backend.py
+++ b/backend.py
@@ -67,7 +67,8 @@ def main(params):
     # integrate alfred nodeinfo
     for alfred in alfred_instances:
         nodes.import_nodeinfo(nodedb['nodes'], alfred.nodeinfo(),
-                              now, assume_online=True)
+                              now, assume_online=True,
+                              hide_ownership=params['hide_ownership'])
 
     # integrate static aliases data
     for aliases in params['aliases']:
@@ -146,7 +147,12 @@ if __name__ == '__main__':
                         help='forget nodes offline for at least DAYS')
     parser.add_argument('--with-rrd', dest='rrd', action='store_true',
                         default=False,
-                        help='enable the rendering of RRD graphs (cpu intensive)')
+                        help='Enable the rendering of RRD graphs '
+                             '(cpu intensive)')
+    parser.add_argument('--with-hidden-ownership', dest='hide_ownership',
+                        action='store_true', default=False,
+                        help='Remove owner/contact information from'
+                             'alfred nodeinfo')
 
     options = vars(parser.parse_args())
     main(options)

--- a/lib/nodes.py
+++ b/lib/nodes.py
@@ -37,9 +37,16 @@ def mark_online(node, now):
     node['flags']['online'] = True
 
 
-def import_nodeinfo(nodes, nodeinfos, now, assume_online=False):
+def import_nodeinfo(nodes, nodeinfos, now, assume_online=False,
+                    hide_ownership=False):
     for nodeinfo in filter(lambda d: 'node_id' in d, nodeinfos):
         node = nodes.setdefault(nodeinfo['node_id'], {'flags': dict()})
+        # hide ownership (--with-hidden-ownership)
+        if hide_ownership:
+            try:
+                del nodeinfo['owner']
+            except KeyError:
+                pass
         node['nodeinfo'] = nodeinfo
         node['flags']['online'] = False
         node['flags']['gateway'] = False


### PR DESCRIPTION
It is recommended to reread ./backend.py --help after this change.

Multiple --mesh, --vpn parameters are now unsupported. Instead pass all interfaces / mac addresses separated by spaces.