### PR TITLE
Survive empty or otherwise non-readable nodes.json

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -60,7 +60,7 @@ def main(params):
     try:
         with open(nodes_fn, 'r') as nodedb_handle:
             nodedb = json.load(nodedb_handle)
-    except (IOError,ValueError):
+    except (IOError, ValueError):
         nodedb = {'nodes': dict()}
 
     # flush nodedb if it uses the old format

--- a/backend.py
+++ b/backend.py
@@ -60,7 +60,7 @@ def main(params):
     try:
         with open(nodes_fn, 'r') as nodedb_handle:
             nodedb = json.load(nodedb_handle)
-    except IOError:
+    except (IOError,ValueError):
         nodedb = {'nodes': dict()}
 
     # flush nodedb if it uses the old format


### PR DESCRIPTION
We ran into a disk full situation while the nodes.json was just about to be recreated. This left nodes.json empty. backend.py could not cope with that situation and cause the script to end prematurely. This change helps to almost always show a current map.
